### PR TITLE
Bugfix: Scroll to hash fix

### DIFF
--- a/src/scrollNav.js
+++ b/src/scrollNav.js
@@ -27,8 +27,11 @@
 
     var viewPort;
     var navOffset;
+    var topBoundry;
+    var bottomBoundry;
     var sections     = [];
     var sectionArray = [];
+    var activeArray  = [];
     var $container   = this;
     var $headline    = $('<span />', {'class': 'scroll-nav__heading', text: settings.headlineText});
     var $wrapper     = $('<div />', {'class': 'scroll-nav__wrapper'});
@@ -160,10 +163,10 @@
     // class to any sections currently within the bounds of our view
 
     var positionCheck = function() {
-      var winTop        = $(window).scrollTop();
-      var topBoundry    = winTop + settings.scrollOffset;
-      var bottomBoundry = winTop + viewPort - settings.scrollOffset;
-      var activeArray   = [];
+      var winTop          = $(window).scrollTop();
+      topBoundry          = winTop + settings.scrollOffset;
+      bottomBoundry       = winTop + viewPort - settings.scrollOffset;
+      activeArray.length  = 0;
 
       if ( winTop > (navOffset - settings.fixedMargin) ) { $nav.addClass('fixed'); }
       else { $nav.removeClass('fixed'); }
@@ -202,27 +205,31 @@
 
     var scrollTo = function(value) {
       var destination = $(value).offset().top;
+      var speed = (settings.animated) ? settings.speed : 0;
 
-      $('html:not(:animated),body:not(:animated)').animate({ scrollTop: destination - settings.scrollOffset }, settings.speed );
+      $('html:not(:animated),body:not(:animated)').animate({ scrollTop: destination - settings.scrollOffset }, speed );
     };
 
-    // Animate scrolling on click
+    // Scroll to section on click
 
-    var animateClicks = function() {
-      if (settings.animated) {
-        $('.scroll-nav').find('a').click(function(e) {
-          e.preventDefault();
+    var initiateClickListeners = function() {
+      $('.scroll-nav').find('a').click(function(e) {
+        e.preventDefault();
 
-          scrollTo( $(this).attr('href') );
-        });
-      }
+        scrollTo( $(this).attr('href') );
+      });
     };
 
-    // If page url contains hash scroll to it
+    // Scroll to section if url has hash
 
     var scrollToHash = function(value) {
-      if ( value ) {
-        scrollTo( value);
+      if (value) {
+        var position = $(value).offset().top;
+        console.log(position);
+
+        if ( position < topBoundry || position > bottomBoundry ) {
+          scrollTo(value);
+        }
       }
     };
 
@@ -241,7 +248,7 @@
         setupPositions();
         positionCheck();
         navScrolling();
-        animateClicks();
+        initiateClickListeners();
         swapLoadingClass(true);
         scrollToHash( getHash() );
       } else {


### PR DESCRIPTION
When reloading a page or returning to a previously viewed page the page would scroll, even if you left it with the section within the view bounds. Conditioned the scrollToHash function to now only scroll to the section if the section is out of the bounds.
