### PR TITLE
Update scroll positions when DOM changes. Fixes #46.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+# System Files
 *.swp
 .DS_Store
+
+# Node Files
 /node_modules/
 npm-debug.log
 bower_components
-_assets

--- a/README.md
+++ b/README.md
@@ -199,6 +199,39 @@ $('.post__article').scrollNav({
 });
 ```
 
+## Reset Positions on DOM Change
+
+There are a couple of ways you can reset scrollNav's positions when the DOM changes:
+
+### Manually
+
+Simply call the `resetPos` method on your own:
+
+```
+$.fn.scrollNav('resetPos');
+```
+
+### Automatically
+
+Utilize [mutation observers][21] to call the `resetPos` method automatically:
+
+```
+var $;
+var observer_target = document.querySelector('.post__article');
+var observer = new MutationObserver(function(mutations) {
+  mutations.forEach(function() {
+    $.fn.scrollNav('resetPos');
+  });
+});
+var observer_config = {
+  attributes: true,
+  childList: true,
+  characterData: true,
+  subtree: true
+};
+observer.observe(observer_target, observer_config);
+```
+
 ## Errors
 
 The plugin will refuse to build and log an error message if it doesn't find your desired container, the insertion target or any of the headlines specified within the container. If the nav doesn't show up on load, check your browser's console.
@@ -267,6 +300,8 @@ Available Grunt tasks that will be useful in development.
 [18]: http://modernizr.com/
 [19]: http://nodejs.org/
 [20]: http://gruntjs.com/
+[21]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+[22]: http://caniuse.com/#search=mutation%20observer
 
 
 

--- a/src/scrollNav.js
+++ b/src/scrollNav.js
@@ -48,7 +48,7 @@
       onInit: null,
       onRender: null,
       onDestroy: null,
-      onReset: null
+      onResetPos: null
     },
     _set_body_class: function(state) {
       // Set and swap our loading hooks to the body
@@ -389,12 +389,12 @@
         S.sections = undefined;
       });
     },
-    reset: function() {
+    resetPos: function() {
       S._setup_pos();
       S._check_pos();
 
-      // Fire custom reset callback
-      if (S.settings.onReset) { S.settings.onReset.call(this); }
+      // Fire custom reset position callback
+      if (S.settings.onResetPos) { S.settings.onResetPos.call(this); }
     }
   };
 
@@ -422,19 +422,3 @@
     return method.apply(this, options);
   };
 })(jQuery);
-
-// Mutation observer ( https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver )
-var $;
-var observer_target = document.querySelector('.post__article');
-var observer = new MutationObserver(function(mutations) {
-  mutations.forEach(function() {
-    $.fn.scrollNav('reset');
-  });
-});
-var observer_config = {
-  attributes: true,
-  childList: true,
-  characterData: true,
-  subtree: true
-};
-observer.observe(observer_target, observer_config);


### PR DESCRIPTION
To update scroll positions, a new public method is provided that can be called manually, anytime. This same method is called, automatically, by a mutation observer in browsers that support it.

(I'm far from good at setting up tests (I've just now discovered), so my huge apologies: all things "test" are not working as far as this PR goes.)
