### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Set this to false if you use hashed (http://example.com/#home) values for routin
 
 ### Callback functions
 
-There are three new callback functions that you can utilize to accomodate anything you need to run after specific scrollNav events. They are `onInit`, `onRender`, and `onDestroy`. Add them to your options just like any other and they should look like this:
+There are three new callback functions that you can utilize to accommodate anything you need to run after specific scrollNav events. They are `onInit`, `onRender`, and `onDestroy`. Add them to your options just like any other and they should look like this:
 
 ```
 $('.post__article').scrollNav({


### PR DESCRIPTION
jimmynotjim, I've corrected a typographical error in the documentation of the [scrollNav](https://github.com/jimmynotjim/scrollNav) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.