### PR TITLE
Add a Class to the "Scrolled To" Section of the Page

### DIFF
--- a/src/scrollNav.js
+++ b/src/scrollNav.js
@@ -14,6 +14,10 @@
       var destination = $(value).offset().top;
       speed = animated ? speed : 0;
 
+	    // Add a class to the scrolled-to section
+	    $('.' + S.settings.className + '__focused-section').removeClass(S.settings.className + '__focused-section');
+	    $(value).addClass(S.settings.className + '__focused-section');
+	  
       $('html:not(:animated),body:not(:animated)')
         .animate({scrollTop: destination - offset }, speed );
     }


### PR DESCRIPTION
Allows for styling of the active page section or one its descendants. 

Works similarly to the `.active` and `.in-view` classes but for the content instead of the `$nav`