### PR TITLE
Fixes for npm package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "type": "git",
     "url": "https://github.com/jimmynotjim/scrollNav.git"
   },
+  "files": [
+    "dist"
+  ],
   "main": "dist/jquery.scrollNav.min.js",
   "bugs": "https://github.com/jimmynotjim/scrollNav/issues",
   "licenses": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrollNav",
+  "name": "scrollnav",
   "version": "2.7.0",
   "title": "scrollNav",
   "author": {
@@ -21,9 +21,7 @@
     "type": "git",
     "url": "https://github.com/jimmynotjim/scrollNav.git"
   },
-  "main": [
-    "./dist/jquery.scrollNav.min.js"
-  ],
+  "main": "dist/jquery.scrollNav.min.js",
   "bugs": "https://github.com/jimmynotjim/scrollNav/issues",
   "licenses": [
     {


### PR DESCRIPTION
Can't have caps for the name, and needs a string path for main.

Added you as an owner on the package:
https://www.npmjs.com/package/scrollnav